### PR TITLE
Static linux builds

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -30,7 +30,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest, macos-latest]
+        os: [ubuntu-20.04, windows-latest, macos-latest]
     # The CMake configure and build commands are platform agnostic
     # and should work equally well on Windows or Mac.
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -30,7 +30,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-18.04, windows-latest, macos-latest]
     # The CMake configure and build commands are platform agnostic
     # and should work equally well on Windows or Mac.
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -30,7 +30,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest ] #, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     # The CMake configure and build commands are platform agnostic
     # and should work equally well on Windows or Mac.
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -30,7 +30,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest ] #, macos-latest]
     # The CMake configure and build commands are platform agnostic
     # and should work equally well on Windows or Mac.
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -30,7 +30,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
     # The CMake configure and build commands are platform agnostic
     # and should work equally well on Windows or Mac.
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -30,7 +30,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     # The CMake configure and build commands are platform agnostic
     # and should work equally well on Windows or Mac.
     runs-on: ${{ matrix.os }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ set(HEADERS ./src/bmai.h ./src/bmai_ai.h ./src/stats.h ./src/logger.h ./src/pars
 
 add_executable(${PROJECT_NAME} ${SOURCE} ${HEADERS})
 
+target_link_libraries(${PROJECT_NAME} -static)
+
 # to be able to reference header files
 target_include_directories(${PROJECT_NAME} PRIVATE ./src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,11 @@ set(HEADERS ./src/bmai.h ./src/bmai_ai.h ./src/stats.h ./src/logger.h ./src/pars
 
 add_executable(${PROJECT_NAME} ${SOURCE} ${HEADERS})
 
-target_link_libraries(${PROJECT_NAME} -static)
+if(UNIX AND NOT APPLE)
+   target_link_libraries(${PROJECT_NAME} -static)
+else()
+    target_link_libraries(${PROJECT_NAME})
+endif()
 
 # to be able to reference header files
 target_include_directories(${PROJECT_NAME} PRIVATE ./src)


### PR DESCRIPTION
when trying to get BMAI running in docker and in lambda I found it really nice to have a static linux build. some people in the button men online community would also like to tinker with BMAI without having to compile. 

I added this line to create static builds that work for my linux needs. When I added `-static` to ALL OSes the Mac build failed and the windows build did not change size. I would like to know what you think @pappde is this not too intrusive? 