### PR TITLE
Fix code scanning alert no. 1: Wrong type of arguments to formatting function

### DIFF
--- a/src/bmai.cpp
+++ b/src/bmai.cpp
@@ -610,7 +610,7 @@ void BMC_DieData::Reset()
 
 void BMC_DieData::Debug(BME_DEBUG _cat)
 {
-	BMF_Log(_cat,"(%x)", m_properties & (~BME_PROPERTY_VALID));
+	BMF_Log(_cat,"(%lx)", m_properties & (~BME_PROPERTY_VALID));
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes [https://github.com/pappde/bmai/security/code-scanning/1](https://github.com/pappde/bmai/security/code-scanning/1)

To fix the problem, we need to ensure that the format specifier matches the type of the argument. Since `m_properties & (~BME_PROPERTY_VALID)` is of type `unsigned long`, we should use the `%lx` format specifier, which is designed for `unsigned long` values.

- Change the format specifier in the `BMF_Log` function call from `%x` to `%lx`.
- This change should be made in the file `src/bmai.cpp` on line 613.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
