### PR TITLE
Combine workflow action version bumps

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -80,7 +80,7 @@ jobs:
     # then the archive won't have a lit of different dirs in it
     # couldn't find an easier way to flatten
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: bmai-${{ runner.os }}-${{ env.BUILD_TYPE }}
         if-no-files-found: error

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - uses: lukka/get-cmake@latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@v5
+        uses: fsfe/reuse-action@v6


### PR DESCRIPTION
Combines the workflow dependency updates from the related PRs into one reviewable branch.

This PR addresses and supersedes:
- #74
- #75
- #77
- #78

Changes included:
- bump `fsfe/reuse-action` from `v5` to `v6`
- bump `github/codeql-action` from `v3` to `v4`
- bump `actions/checkout` from `v4` to `v6`
- bump `actions/upload-artifact` from `v4` to `v6`

Verification:
- clean configure succeeded
- clean build succeeded
- full test run in a fresh `main`-based worktree still shows one pre-existing failure on `main`:
  - `BMAI3Tests/BMAIActionTests.CheckSurrenderAction/5` for `test/Insult_in.txt`
- no new failures attributable to these workflow-only changes
