### PR TITLE
Fix assert-based reroll contract handling

### DIFF
--- a/src/BMC_Die.cpp
+++ b/src/BMC_Die.cpp
@@ -10,6 +10,7 @@
 // dbl100524 - broke this logic out into its own class file
 // dbl021125 - stealth dice can only interface with skill attacks
 // dbl032526 - allow single-die skill; enforce that Stealth overrides added attacks and only interacts via multi-die skill
+// dbl040626 - fix NOTSET assert checks and make attacker/trip rerolls and warrior Konstant handling state-driven
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 #include "BMC_Die.h"
@@ -180,7 +181,7 @@ void BMC_Die::OnSwingSet(INT _swing, U8 _value)
 	if (!IsUsed())
 		return;
 
-	BM_ASSERT(m_state=BME_STATE_NOTSET);
+	BM_ASSERT(m_state==BME_STATE_NOTSET);
 
 	INT i;
 	m_sides_max = 0;
@@ -221,7 +222,7 @@ void BMC_Die::Roll()
 	if (!IsUsed())
 		return;
 
-	BM_ASSERT(m_state=BME_STATE_NOTSET);
+	BM_ASSERT(m_state==BME_STATE_NOTSET);
 
 	INT i;
 	m_value_total = 0;
@@ -286,8 +287,7 @@ void BMC_Die::OnApplyAttackPlayer(BMC_Move &_move, BMC_Player *_owner, bool _act
     // TODO determine how this may conflict with the design of `bool _actually_attacking`
     BM_ASSERT(c_attack_type[_move.m_attack]!=BME_ATTACK_TYPE_0_0);
 
-	// clear value
-	// KONSTANT: don't reroll
+	// clear value: Konstant attackers keep their current value and never enter the reroll state
 	if (!HasProperty(BME_PROPERTY_KONSTANT))
 		SetState(BME_STATE_NOTSET);
 
@@ -357,12 +357,13 @@ void BMC_Die::OnApplyAttackPlayer(BMC_Move &_move, BMC_Player *_owner, bool _act
 
 
 	// WARRIOR: loses property
-	// TODO: KONSTANT will be forced to reroll but shouldn't (OnDieSidesChanging misinterpreting situation)
 	if (HasProperty(BME_PROPERTY_WARRIOR))
 	{
-		_owner->OnDieSidesChanging(this);
+		_owner->OnDiePropertiesChanging(this);
 		m_properties &= ~BME_PROPERTY_WARRIOR;
-		_owner->OnDieSidesChanged(this);
+		if (HasProperty(BME_PROPERTY_KONSTANT))
+			RecomputeAttacks();
+		_owner->OnDiePropertiesChanged(this);
 	}
 }
 
@@ -439,13 +440,15 @@ void BMC_Die::OnApplyAttackNatureRollAttacker(BMC_Move &_move, BMC_Player *_owne
 	}
 
 	// reroll
-	Roll();
+	if (GetState()==BME_STATE_NOTSET)
+		Roll();
 }
 
 void BMC_Die::OnApplyAttackNatureRollTripped()
 {
 	// reroll
-	Roll();
+	if (GetState()==BME_STATE_NOTSET)
+		Roll();
 }
 
 void BMC_Die::Debug(BME_DEBUG _cat)

--- a/src/BMC_Game.cpp
+++ b/src/BMC_Game.cpp
@@ -11,6 +11,7 @@
 // dbl100524 - broke this logic out into its own class file
 // dbl021125 - adjust to new Die::CanDoAttack()/Die::CanBeAttacked() signatures
 // dbl032526 - allow single-die skill; enforce that Stealth overrides added attacks and only interacts via multi-die skill as attacker or target
+// dbl040626 - schedule Chance and Trip rerolls only for dice that should actually reroll
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 #include "BMC_Game.h"
@@ -1280,9 +1281,11 @@ void BMC_Game::ApplyUseChance(BMC_Move &_move)
 			continue;
 		die = player->GetDie(i);
 
-		// ASSUME: just Roll() - no special effects, so not calling OnBeforeRollInGame()
-		die->SetState(BME_STATE_NOTSET);
-		die->Roll();
+		// CHANCE rerolls preserve Konstant values, so only schedule a reroll for dice that should change.
+		if (!die->HasProperty(BME_PROPERTY_KONSTANT))
+			die->SetState(BME_STATE_NOTSET);
+		if (die->GetState()==BME_STATE_NOTSET)
+			die->Roll();
 	}
 
 	// reoptimize dice
@@ -1452,7 +1455,7 @@ void BMC_Game::ApplyAttackPlayer(BMC_Move &_move)
 		}
 	}
 
-	// for TRIP, mark target as needing a reroll
+	// for TRIP, mark non-Konstant targets as needing a reroll
 	if (_move.m_attack == BME_ATTACK_TRIP)
 	{
 		BM_ASSERT(c_attack_type[_move.m_attack]==BME_ATTACK_TYPE_1_1);
@@ -1461,8 +1464,11 @@ void BMC_Game::ApplyAttackPlayer(BMC_Move &_move)
 		BMC_Player *target = &(m_player[m_target_player]);
 
 		tgt_die = target->GetDie(_move.m_target);
-		tgt_die->SetState(BME_STATE_NOTSET);
-		tgt_die->OnBeforeRollInGame(target);
+		if (!tgt_die->HasProperty(BME_PROPERTY_KONSTANT))
+		{
+			tgt_die->SetState(BME_STATE_NOTSET);
+			tgt_die->OnBeforeRollInGame(target);
+		}
 	}
 
 	// ORNERY: all ornery dice on attacker must reroll (whether attacked)
@@ -1515,10 +1521,15 @@ void BMC_Game::ApplyAttackNatureRoll(BMC_Move &_move)
 	// TRIP attack
 	if (_move.m_attack == BME_ATTACK_TRIP)
 	{
-		// reroll target
+		// reroll target if the attack scheduled one
 		BM_ASSERT(c_attack_type[_move.m_attack]==BME_ATTACK_TYPE_1_1);
 
 		tgt_die = target->GetDie(_move.m_target);
+		if (!tgt_die->HasProperty(BME_PROPERTY_KONSTANT))
+		{
+			tgt_die->SetState(BME_STATE_NOTSET);
+			tgt_die->OnBeforeRollInGame(target);
+		}
 		tgt_die->OnApplyAttackNatureRollTripped();
 	}
 }

--- a/src/BMC_Parser.h
+++ b/src/BMC_Parser.h
@@ -10,6 +10,7 @@
 // REVISION HISTORY:
 // drp030321 - partial split out to individual headers
 // dbl100524 - further split out of individual headers
+// dbl040626 - expose parser-owned game for parser-driven tests
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 #pragma once
@@ -31,6 +32,7 @@ public:
 	void	ParseStdIn() { m_inputFile = stdin; Parse(); }
 	void	ParseFile(FILE *_fp) { m_inputFile = _fp; Parse(); }
 	void	ParseString(std::string  _data);
+	BMC_Game *Game() { return &m_game; }
 
 protected:
 	void			GetAction();

--- a/src/BMC_Player.cpp
+++ b/src/BMC_Player.cpp
@@ -9,6 +9,7 @@
 //
 // REVISION HISTORY:
 // dbl100524 - broke this logic out into its own class file
+// dbl040626 - add property-change bookkeeping for warrior Konstant transitions
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 // includes
@@ -223,14 +224,21 @@ void BMC_Player::OptimizeDice()
 	}
 }
 
+void BMC_Player::OnDiePropertiesChanging(BMC_Die *_die)
+{
+	m_score -= _die->GetScore(true);
+}
+
+void BMC_Player::OnDiePropertiesChanged(BMC_Die *_die)
+{
+	m_score += _die->GetScore(true);
+}
+
 void BMC_Player::OnDieSidesChanging(BMC_Die *_die)
 {
-	// KONSTANT: if die was set to not reroll, but we're about to change the number of sides, then force a reroll
+	// Side changes invalidate the current value, even for dice that otherwise preserve it between attacks.
 	if (_die->GetState()!=BME_STATE_NOTSET)
-	{
-		BM_ERROR(_die->HasProperty(BME_PROPERTY_KONSTANT));
 		_die->SetState(BME_STATE_NOTSET);
-	}
 	m_score -= _die->GetScore(true);
 }
 

--- a/src/BMC_Player.h
+++ b/src/BMC_Player.h
@@ -10,6 +10,7 @@
 // REVISION HISTORY:
 // drp030321 - partial split out to individual headers
 // dbl100524 - further split out of individual headers
+// dbl040626 - add property-change bookkeeping hooks for warrior Konstant transitions
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 #pragma once
@@ -48,6 +49,8 @@ public:
 	bool		NeedsSetSwing();
 
 	// events
+	void		OnDiePropertiesChanging(BMC_Die *_die);
+	void		OnDiePropertiesChanged(BMC_Die *_die);
 	void		OnDieSidesChanging(BMC_Die *_die);
 	void		OnDieSidesChanged(BMC_Die *_die);
 	BMC_Die *	OnDieLost(INT _d);

--- a/test/SkillTest.cpp
+++ b/test/SkillTest.cpp
@@ -145,22 +145,30 @@ TEST(SkillTests, RollRequiresNotSetState) {
     BMC_Die die = TEST_Util::createTestDie(6, BME_PROPERTY_VALID);
 
 	// Roll/BM_ASSERT should fail if state not set correctly
+#ifdef NDEBUG
+    GTEST_SKIP() << "assert() is compiled out in release builds";
+#else
     EXPECT_DEATH(
         {
             die.Roll();
         },
         "");
+#endif
 }
 
 TEST(SkillTests, SwingSetRequiresNotSetState) {
     BMC_Die die = TEST_Util::createTestDie(6, BME_PROPERTY_VALID, BME_SWING_X);
 
 	// Roll/BM_ASSERT should fail if state not set correctly
+#ifdef NDEBUG
+    GTEST_SKIP() << "assert() is compiled out in release builds";
+#else
     EXPECT_DEATH(
         {
             die.OnSwingSet(BME_SWING_X, 8);
         },
         "");
+#endif
 }
 
 TEST(SkillTests, KonstantRetainsValueWhenTripped) {

--- a/test/SkillTest.cpp
+++ b/test/SkillTest.cpp
@@ -8,6 +8,20 @@
 #include "./_matchers.h"
 #include "./_testutils.h"
 #include "../src/BMC_Parser.h"
+#include "../src/BMC_RNG.h"
+
+namespace {
+
+BMC_Die *FindDieByOriginalIndex(BMC_Player *player, int original_index) {
+	for (int i = 0; i < player->GetAvailableDice(); ++i) {
+		BMC_Die *die = player->GetDie(i);
+		if (die->GetOriginalIndex() == original_index)
+			return die;
+	}
+	return nullptr;
+}
+
+}  // namespace
 
 TEST(SkillTests, NoSkill) {
 	TEST_Util test;
@@ -119,11 +133,131 @@ TEST(SkillTests, MaximumSkill) {
 
     for (int i = 0; i < 10; ++i) {
         // Act: When the die is rolled 10 times
+        die.SetState(BME_STATE_NOTSET);
         die.Roll();
 
         // Assert: Then it always has the max value
         EXPECT_EQ(die.GetValueTotal(), 6);
     }
+}
+
+TEST(SkillTests, RollRequiresNotSetState) {
+    BMC_Die die = TEST_Util::createTestDie(6, BME_PROPERTY_VALID);
+
+	// Roll/BM_ASSERT should fail if state not set correctly
+    EXPECT_DEATH(
+        {
+            die.Roll();
+        },
+        "");
+}
+
+TEST(SkillTests, SwingSetRequiresNotSetState) {
+    BMC_Die die = TEST_Util::createTestDie(6, BME_PROPERTY_VALID, BME_SWING_X);
+
+	// Roll/BM_ASSERT should fail if state not set correctly
+    EXPECT_DEATH(
+        {
+            die.OnSwingSet(BME_SWING_X, 8);
+        },
+        "");
+}
+
+TEST(SkillTests, KonstantRetainsValueWhenTripped) {
+	TEST_Util test;
+
+	auto context = test.ParseFightContext("tk8:8", "k100:7");
+	auto valid_attacks = context.ValidAttacks();
+	ASSERT_THAT(valid_attacks, ::testing::UnorderedElementsAre(
+		IsAttack(BME_ATTACK_TYPE_1_1, "trip", 0, 0)
+	));
+
+	// Fix the RNG seed so a broken reroll path cannot randomly land back on 7 and mask the bug.
+	g_rng.SRand(1);
+
+	bool extra_turn = false;
+	context.Game()->SimulateAttack(valid_attacks.front(), extra_turn);
+
+	BMC_Player *target_player = context.Game()->GetPlayer(1);
+	EXPECT_EQ(target_player->GetDie(0)->GetValueTotal(), 7);
+	EXPECT_EQ(target_player->GetAvailableDice(), 0);
+}
+
+TEST(SkillTests, KonstantRetainsValueWhenChanceRerolls) {
+	TEST_Util test;
+
+	auto context = test.ParseChanceContext("ck100:7", "20:20");
+	auto valid_chance = context.ValidChance();
+
+	auto chance_it = std::find_if(valid_chance.begin(), valid_chance.end(), [](const BMC_Move &move) {
+		return move.m_action == BME_ACTION_USE_CHANCE;
+	});
+	ASSERT_NE(chance_it, valid_chance.end());
+
+	// Fix the RNG seed so a broken reroll path cannot randomly land back on 7 and mask the bug.
+	g_rng.SRand(1);
+
+	context.Game()->ApplyUseChance(*chance_it);
+
+	BMC_Player *chance_player = context.Game()->GetPlayer(0);
+	// Die should not have re-rolled
+	EXPECT_EQ(chance_player->GetDie(0)->GetValueTotal(), 7);
+}
+
+TEST(SkillTests, KonstantAttackerRetainsValueAfterSkillAttack) {
+	TEST_Util test;
+
+	auto context = test.ParseFightContext("k20:13 7:7", "20:20");
+	auto valid_attacks = context.ValidAttacks();
+	ASSERT_THAT(valid_attacks, ::testing::UnorderedElementsAre(
+		IsAttack(BME_ATTACK_TYPE_N_1, "skill", {0, 1}, 0)
+	));
+
+	BMC_Player *attacker = context.Game()->GetPlayer(0);
+	BMC_Die *konstant_die = attacker->GetDie(0);
+	ASSERT_NE(konstant_die, nullptr);
+	int original_index = konstant_die->GetOriginalIndex();
+	ASSERT_EQ(konstant_die->GetValueTotal(), 13);
+
+	g_rng.SRand(1);
+
+	bool extra_turn = false;
+	context.Game()->SimulateAttack(valid_attacks.front(), extra_turn);
+
+	attacker = context.Game()->GetPlayer(0);
+	konstant_die = FindDieByOriginalIndex(attacker, original_index);
+	ASSERT_NE(konstant_die, nullptr);
+	// Die should not have re-rolled
+	EXPECT_EQ(konstant_die->GetValueTotal(), 13);
+}
+
+TEST(SkillTests, KonstantWarriorRetainsValueWhenUsedInSkillAttack) {
+	TEST_Util test;
+
+	auto context = test.ParseFightContext("`k41:17 11:11", "20:28");
+	auto valid_attacks = context.ValidAttacks();
+	ASSERT_THAT(valid_attacks, ::testing::UnorderedElementsAre(
+		IsAttack(BME_ATTACK_TYPE_N_1, "skill", {0, 1}, 0)
+	));
+
+	BMC_Player *attacker = context.Game()->GetPlayer(0);
+	BMC_Die *warrior_die = attacker->GetDie(0);
+	ASSERT_NE(warrior_die, nullptr);
+	int original_index = warrior_die->GetOriginalIndex();
+	ASSERT_EQ(warrior_die->GetValueTotal(), 17);
+	ASSERT_TRUE(warrior_die->HasProperty(BME_PROPERTY_WARRIOR));
+
+	g_rng.SRand(1);
+
+	bool extra_turn = false;
+	context.Game()->SimulateAttack(valid_attacks.front(), extra_turn);
+
+	attacker = context.Game()->GetPlayer(0);
+	warrior_die = FindDieByOriginalIndex(attacker, original_index);
+	ASSERT_NE(warrior_die, nullptr);
+	// Die should not have re-rolled
+	EXPECT_EQ(warrior_die->GetValueTotal(), 17);
+	EXPECT_FALSE(warrior_die->HasProperty(BME_PROPERTY_WARRIOR));
 }
 
 TEST(SkillTests, InsultSkill) {

--- a/test/SkillTest.cpp
+++ b/test/SkillTest.cpp
@@ -144,7 +144,7 @@ TEST(SkillTests, MaximumSkill) {
 TEST(SkillTests, RollRequiresNotSetState) {
     BMC_Die die = TEST_Util::createTestDie(6, BME_PROPERTY_VALID);
 
-	// Roll/BM_ASSERT should fail if state not set correctly
+    // This invariant is enforced only in debug builds, where assert() is active.
 #ifdef NDEBUG
     GTEST_SKIP() << "assert() is compiled out in release builds";
 #else
@@ -159,7 +159,7 @@ TEST(SkillTests, RollRequiresNotSetState) {
 TEST(SkillTests, SwingSetRequiresNotSetState) {
     BMC_Die die = TEST_Util::createTestDie(6, BME_PROPERTY_VALID, BME_SWING_X);
 
-	// Roll/BM_ASSERT should fail if state not set correctly
+    // This invariant is enforced only in debug builds, where assert() is active.
 #ifdef NDEBUG
     GTEST_SKIP() << "assert() is compiled out in release builds";
 #else

--- a/test/_testutils.h
+++ b/test/_testutils.h
@@ -7,6 +7,7 @@
 #include <cstdarg>
 #include <cstdio>
 #include <iostream>
+#include <memory>
 
 #include "../src/BMC_Die.h"
 #include "../src/BMC_Game.h"
@@ -72,14 +73,15 @@ public:
 class TEST_Util
 {
 public:
-	struct FightContext
+	struct PhaseContext
 	{
-		TEST_Parser parser;
+		std::unique_ptr<TEST_Parser> parser;
+		BMC_Game *game = nullptr;
 		BMC_Move chosen_move;
 
 		BMC_Game* Game() const
 		{
-			return chosen_move.m_game;
+			return game;
 		}
 
 		std::vector<BMC_Move> ValidAttacks() const
@@ -92,7 +94,19 @@ public:
 				moves.push_back(*movelist.Get(i));
 			return moves;
 		}
+
+		std::vector<BMC_Move> ValidChance() const
+		{
+			BMC_MoveList movelist;
+			Game()->GenerateValidChance(movelist);
+
+			std::vector<BMC_Move> moves;
+			for (int i = 0; i < movelist.Size(); ++i)
+				moves.push_back(*movelist.Get(i));
+			return moves;
+		}
 	};
+	using FightContext = PhaseContext;
 
 	TEST_Parser parser;
 
@@ -114,14 +128,15 @@ public:
 		return parser.last_attack;
 	}
 
-	FightContext ParseFightContext(std::string d0, std::string d1)
+	PhaseContext ParsePhaseContext(std::string phase, std::string d0, std::string d1)
 	{
-		FightContext context;
+		PhaseContext context;
+		context.parser = std::make_unique<TEST_Parser>();
 		auto dice0 = split(d0, ' ');
 		auto dice1 = split(d1, ' ');
 
 		std::stringstream ss;
-		ss << "game\nfight\n";
+		ss << "game\n" << phase << "\n";
 		ss << "player 0 " << dice0.size() << " 0\n";
 		for (int i=0; i<dice0.size(); i++)
 			ss << dice0[i] << "\n";
@@ -129,9 +144,20 @@ public:
 		for (int i=0; i<dice1.size(); i++)
 			ss << dice1[i] << "\n";
 		ss << "ply 1\nsurrender off\ngetaction\n";
-		context.parser.ParseString(ss.str());
-		context.chosen_move = context.parser.last_attack;
+		context.parser->ParseString(ss.str());
+		context.game = context.parser->Game();
+		context.chosen_move = context.parser->last_attack;
 		return context;
+	}
+
+	FightContext ParseFightContext(std::string d0, std::string d1)
+	{
+		return ParsePhaseContext("fight", d0, d1);
+	}
+
+	PhaseContext ParseChanceContext(std::string d0, std::string d1)
+	{
+		return ParsePhaseContext("chance", d0, d1);
 	}
 
 	static std::vector<std::string> split(std::string &str, char delimiter)


### PR DESCRIPTION
## Summary
- fix two BM_ASSERT call sites that were assigning state instead of checking it
- make reroll paths state-driven so Roll() and OnSwingSet() only run from NOTSET
- add direct invariant tests plus reroll regression coverage for trip, chance, attacker, and warrior paths

## Notes
- the direct assert death tests skip under NDEBUG because GitHub Actions runs Release builds
- all GitHub Actions runners are green on this branch
